### PR TITLE
Turn on/off formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,18 @@ x23LimitStringx23
 
 fi
 ```
+
+Special comments '@formatter:off' and '@formatter:on' can be used to disable formatting around a block of statements.
+
+```shell
+# @formatter:off
+command \
+    --option1 \
+        --option2 \
+            --option3 \
+# @formatter:on
+
+This is modeled after the Eclipse feature.
 ________________________________________________________________________________
 
 Originally written by [Paul Lutus](http://arachnoid.com/python/beautify_bash_program.html)

--- a/beautysh/beautysh.py
+++ b/beautysh/beautysh.py
@@ -41,6 +41,7 @@ class Beautify:
         here_string = ''
         output = []
         line = 1
+        formatter = True
         for record in re.split('\n', data):
             record = record.rstrip()
             stripped_record = record.strip()
@@ -87,10 +88,18 @@ class Beautify:
                         test_record = re.sub(
                             '(.*)%s.*' % ext_quote_string, '\\1',
                             test_record, 1)
-                if(in_ext_quote):
+                if(in_ext_quote or not formatter):
                     # pass on unchanged
                     output.append(record)
+                    if(re.search(r'#\s*@formatter:on', stripped_record)):
+                        formatter = True
+                        continue
                 else:  # not in ext quote
+                    if(re.search(r'#\s*@formatter:off', stripped_record)):
+                        formatter = False
+                        output.append(record)
+                        continue
+
                     inc = len(re.findall(
                         '(\s|\A|;)(case|then|do)(;|\Z|\s)', test_record))
                     inc += len(re.findall('(\{|\(|\[)', test_record))


### PR DESCRIPTION
Add special comments to turn on and off formatting. Modeled
after the Eclipse formatter support

	# @formatter:off
	command \
	    --option1 \
		--option2 \
		    --option3 \
	# @formatter:on

Allows skipping any code that breaks formatter. :-)

Signed-off-by: Jhon Honce <jhonce@redhat.com>