### PR TITLE
Improve case statement formatting

### DIFF
--- a/beautysh/beautysh.py
+++ b/beautysh/beautysh.py
@@ -33,7 +33,7 @@ class Beautify:
     def beautify_string(self, data, path=''):
         """Beautify string (file part)."""
         tab = 0
-        case_stack = []
+        case_level = 0
         in_here_doc = False
         defer_ext_quote = False
         in_ext_quote = False
@@ -112,20 +112,21 @@ class Beautify:
                         test_record))
                     outc += len(re.findall('(\}|\)|\])', test_record))
                     if(re.search(r'\besac\b', test_record)):
-                        if(len(case_stack) == 0):
+                        if(case_level == 0):
                             sys.stderr.write(
                                 'File %s: error: "esac" before "case" in '
                                 'line %d.\n' % (path, line))
                         else:
-                            outc += case_stack.pop()
+                            outc += 1
+                            case_level -= 1
 
                     # special handling for bad syntax within case ... esac
                     if re.search(r'\bcase\b', test_record):
                         inc += 1
-                        case_stack.append(1)
+                        case_level += 1
 
                     choice_case = 0
-                    if(len(case_stack) > 0):
+                    if case_level:
                         if(re.search('\A[^(]*\)', test_record)):
                             inc += 1
                             choice_case = -1

--- a/beautysh/beautysh.py
+++ b/beautysh/beautysh.py
@@ -46,9 +46,9 @@ class Beautify:
             record = record.rstrip()
             stripped_record = record.strip()
 
-            # remove spaces before ;; terminators in case statements
-            if case_stack:
-                stripped_record = re.sub(r'\s;;', r';;', stripped_record)
+            # ensure space before ;; terminators in case statements
+            if case_level:
+                stripped_record = re.sub(r'(\S);;', r'\1 ;;', stripped_record)
 
             # collapse multiple quotes between ' ... '
             test_record = re.sub(r'\'.*?\'', '', stripped_record)


### PR DESCRIPTION
Modeled after the TLDP advanced bash scripting guide
http://tldp.org/LDP/abs/html/testbranch.html#EX29

Before:
```
case "${blah}" in
    one) make alpha ;;
    two)
    make beta;;
    twoandahalf)
        case "${blue}" in
            four) make alpha ;;
            five)
            make beta;;
            six)
                make alpha
                make beta
                make release
            ;;
        esac
        three)
            make alpha
            make beta
            make release
        ;;
esac
```

After:
```
case "${blah}" in
    one) make alpha ;;
    two)
        make beta ;;
    twoandahalf)
        case "${blue}" in
            four) make alpha ;;
            five)
                make beta ;;
            six)
                make alpha
                make beta
                make release
                ;;
        esac
    three)
        make alpha
        make beta
        make release
        ;;
esac
```
Ensuring the space before a `;;` isn't the example found in TLDP advanced bash scripting guide, but I do feel it makes the code more readable and consistent.
