### PR TITLE
Add a pre-commit config so beautysh can be used as a pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: beautysh
+  name: beautysh
+  description: |
+    A Bash beautifier for the masses.
+    https://pypi.python.org/pypi/beautysh
+  entry: beautysh -f
+  language: python
+  types: [shell]


### PR DESCRIPTION
I'd like to use beautysh as a [pre-commit hook](https://pre-commit.com/) for some shell script projects. To use this hook in a repo, create a `.pre-commit-config.yaml` in the repo root with the following, then run `pre-commit install --install-hooks`.

```
repos:
  - repo: https://github.com/bemeurer/beautysh
    sha: 3.5 # or whatever tag this change might be released in
    hooks:
      - id: beautysh
```