### PR TITLE
Ensure that blank lines are preserved without adding indentation

### DIFF
--- a/beautysh/beautysh.py
+++ b/beautysh/beautysh.py
@@ -46,6 +46,11 @@ class Beautify:
             record = record.rstrip()
             stripped_record = record.strip()
 
+            # preserve blank lines
+            if not stripped_record:
+                output.append(stripped_record)
+                continue
+
             # ensure space before ;; terminators in case statements
             if case_level:
                 stripped_record = re.sub(r'(\S);;', r'\1 ;;', stripped_record)


### PR DESCRIPTION
The output of beautysh currently outputs indentation on lines that are otherwise blank. Most engineers I know have their editors set to strip whitespace from the end of lines. This change ensures that blank lines remain so.