### PR TITLE
Prevent specific while loop to be recognized as heredoc

### DIFF
--- a/beautysh/beautysh.py
+++ b/beautysh/beautysh.py
@@ -77,7 +77,7 @@ class Beautify:
                    re.search(r'<<', test_record)):
                     in_here_doc = False
             else:  # not in here doc
-                if(re.search(r'<<-?', test_record)):
+                if(re.search(r'<<-?', test_record)) and not (re.search(r'done.*<<<', test_record)):
                     here_string = re.sub(
                         r'.*<<-?\s*[\'|"]?([_|\w]+)[\'|"]?.*', r'\1',
                         stripped_record, 1)


### PR DESCRIPTION
This change should fix issues with while loops formatted the following way:
```
while read -r thing; do
    echo "$thing done"
done <<< $filename
```

beautysh.py was parsing that `<<< $filename` as a heredoc delimiter, enabling a heredoc paragraph that was never being closed.
And that was the cause for the error message of those indent/outdent mismatch: the indentation was the same as the one in `done <<< $filename` till the end of file.
Now, before enabling heredoc, we double check if it really isn't a while case.

This should fix #23.