### PR TITLE
here strings not just after loops

### DIFF
--- a/beautysh/beautysh.py
+++ b/beautysh/beautysh.py
@@ -77,7 +77,7 @@ class Beautify:
                    re.search(r'<<', test_record)):
                     in_here_doc = False
             else:  # not in here doc
-                if(re.search(r'<<-?', test_record)) and not (re.search(r'done.*<<<', test_record)):
+                if(re.search(r'<<-?', test_record)) and not (re.search(r'.*<<<', test_record)):
                     here_string = re.sub(
                         r'.*<<-?\s*[\'|"]?([_|\w]+)[\'|"]?.*', r'\1',
                         stripped_record, 1)


### PR DESCRIPTION
I ran into the issue described in issue #11.  One of the comments in that thread says that:

> The problem is indeed the <<< here-string syntax. Beautysh mostly assumes that any appearance of << indicates a here document, which is false. The above commit changed beautysh to exclude a very specific use of here strings (i.e., the ones at the ends of while loops), but doesn't address broader use of here strings.

As far as I can tell, excluding all instances of here-strings should be fine.  It certainly fixed my problem.