### PR TITLE
Include license in sdist and wheel

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE README.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [metadata]
 description-file = README.md
+license_file = LICENSE


### PR DESCRIPTION
Hi! Thanks for the work!

When I checked this out a few days ago, it was GPL 3.0, which _does_ require the license, but I see now that it's MIT... but it's still generally a Good Thing to include this info in the distributions!

In related news, I'm working on getting this added to [conda-forge](https://github.com/conda-forge/staged-recipes/pull/6496).

Thanks again!