### PR TITLE
Add new testcase about multiline lines

### DIFF
--- a/tests/indent_test1_beautified.sh
+++ b/tests/indent_test1_beautified.sh
@@ -25,6 +25,15 @@ function quote_escapes1()
     echo "command to indent"
 }
 
+function quote_escapes_line_continuation2()
+{
+    local EVIL_STRING="{\"time\":{\"last\":{\"value\":1,\"type\":\"days\",\"clockType\":\"days\",\"start\":${TEST_START_TIME}},\"to\":${TEST_END_TIME},\"from\":${TEST_START_TIME_PLUS_ONE}}, \
+\"categories\":{\"category\":[${CATEGORY_FOR_EMPIRIX_EXMS_QUERY}]},\"requestedRows\":1000,\
+\"advancedFilters\":[{\"groupOperator\":\"or\",\"advancedFilter\":[{\"filter\":[{\"name\":\"${PARAM}\",\"type\":\"string\",\"condition\":\"=\",\"value\":[\"${VALUE}\"]}],\
+\"filterOperator\":\"and\"}],\"asdr\":\"common\"}]}"
+    echo "command to indent"
+}
+
 function complex_mix1()
 {
     while true; do

--- a/tests/indent_test1_raw.sh
+++ b/tests/indent_test1_raw.sh
@@ -25,6 +25,15 @@ function quote_escapes1()
 	echo "command to indent"
 }
 
+function quote_escapes_line_continuation2()
+{
+	local EVIL_STRING="{\"time\":{\"last\":{\"value\":1,\"type\":\"days\",\"clockType\":\"days\",\"start\":${TEST_START_TIME}},\"to\":${TEST_END_TIME},\"from\":${TEST_START_TIME_PLUS_ONE}}, \
+\"categories\":{\"category\":[${CATEGORY_FOR_EMPIRIX_EXMS_QUERY}]},\"requestedRows\":1000,\
+\"advancedFilters\":[{\"groupOperator\":\"or\",\"advancedFilter\":[{\"filter\":[{\"name\":\"${PARAM}\",\"type\":\"string\",\"condition\":\"=\",\"value\":[\"${VALUE}\"]}],\
+\"filterOperator\":\"and\"}],\"asdr\":\"common\"}]}"
+	echo "command to indent"
+}
+
 function complex_mix1()
 {
 	while true; do


### PR DESCRIPTION
Today I found a weird case inside a shell script that was puzzling beautysh.
The root problem was a string written on multiple lines (using line continuation \) and that was containing brackets. This was causing beautysh indentation logic to fail.

I tried to fix the issue (see new testcase with EVIL_STRING) but I could not understand the code

```
+ (1 if continue_line and not open_brackets else 0)
```

in "extab" computation so for now I simply removed it (otherwise the unit test fails)...
